### PR TITLE
feat: 중간테이블 생성, user 관련 api제작

### DIFF
--- a/controllers/boothLikeController.js
+++ b/controllers/boothLikeController.js
@@ -1,0 +1,47 @@
+const User = require('../models/user');
+const Photobooth = require('../models/photobooth');
+
+// 부스 즐겨찾기 추가
+const addBoothLike = async(user_id, photobooth_id) => {
+    const user = User.findByPk(user_id);
+    const booth = Photobooth.findByPk(photobooth_id);
+
+    if (user && booth) {
+        await user.addLikedBooths(booth);
+        console.log('포토부스가 즐겨찾기 되었습니다.');
+    }
+};
+
+// 부스 즐겨찾기 삭제
+const deleteBoothLike = async(user_id, photobooth_id) => {
+    const user = User.findByPk(user_id);
+    const booth = Photobooth.findByPk(photobooth_id);
+
+    if (user && booth) {
+        await user.removeLikedBooths(booth);
+        console.log('포토부스가 즐겨찾기 해제 되었습니다.');
+    }
+};
+
+// 해당 회원이 즐겨찾기한 부스 불러오기
+const readBoothLike = async(req, res) => {
+    try {
+        const user_id = req.params.user_id;
+        const user = await User.findByPk(user_id, {
+            include: {
+                model: Photobooth,
+                as: 'likedBooths'
+            }
+        });
+        if (!user) {
+            return res.status(404).json({ message: '유저를 찾을 수 없습니다.' });
+        }
+
+        return res.status(200).json(user.likedBooths);
+    } catch (error) {
+        console.error(error);
+        return res.status(500).json({ message: '즐겨찾는 부스 조회 실패', error });
+    }
+};
+
+module.exports = { addBoothLike, deleteBoothLike, readBoothLike };

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -1,0 +1,58 @@
+const User = require('../models/user');
+
+// id로 유저 조회 (Json으로 결과 반환)
+const getUserById = async (req, res) => {
+    try {
+        const user_id = req.params.user_id;
+        const user = await User.findByPk(user_id);
+        if (!user) {
+            return res.status(404).json({ message: '유저를 찾을 수 없습니다.' });
+        }
+        return res.status(200).json(user);
+    } catch (error) {
+        console.error(error);
+        return res.status(500).json({ message: '유저 조회 실패', error });
+    }
+};
+
+// 회원정보 수정
+const updateUser = async (req, res) => {
+    try {
+        const user_id = req.params.user_id;
+        const { name, email, profileImage } = req.body;
+        const user = await User.findByPk(user_id);
+        if (!user) {
+            return res.status(404).json({ message: '유저를 찾을 수 없습니다.' });
+        }
+        user.name = name;
+        user.email = email;
+        user.profileImage = profileImage;
+        await user.save();
+        return res.status(200).json(user);
+    } catch (error) {
+        console.error(error);
+        return res.status(500).json({ message: '유저 업데이트 실패', error });
+    }
+};
+
+// 회원 탈퇴
+const deleteUser = async (req, res) => {
+    try {
+        const user_id = req.params.user_id;
+        const user = await User.findByPk(user_id);
+        
+        // 해당 id 에 맞는 유저가 존재하지 않음
+        if (!user) {
+            return res.status(404).json({ message: '유저를 찾을 수 없습니다.' });
+        }
+        
+        // 탈퇴: 성공하면 204 코드
+        await user.destroy();
+        return res.status(204).json({message: '탈퇴 성공했습니다.'});
+    } catch (error) {
+        console.error(error);
+        return res.status(500).json({ message: '유저 삭제 실패', error });
+    }
+};
+
+module.exports = { getUserById, updateUser, deleteUser };

--- a/index.js
+++ b/index.js
@@ -50,6 +50,9 @@ app.use('/auth', authRouter);
 const reviewRouter = require('./routes/reviewRoutes');
 app.use('/api/review', reviewRouter);
 
+const userRouter = require('./routes/userRoutes');
+app.use('/api/user', userRouter);
+
 app.listen(port, () => {
   console.log(`Server is running on port ${port}`);
 });

--- a/models/index.js
+++ b/models/index.js
@@ -17,14 +17,16 @@ db.Sequelize = Sequelize;
 
 db.User = User;
 User.init(sequelize);
-User.associate(db);
 
 db.Photobooth = Photobooth;  
 Photobooth.init(sequelize);
-Photobooth.associate(db);
 
 db.Review = Review;
 Review.init(sequelize);
+
+// 관계 설정
+User.associate(db);
+Photobooth.associate(db);
 Review.associate(db);
 
 module.exports = db;

--- a/models/photobooth.js
+++ b/models/photobooth.js
@@ -49,6 +49,14 @@ class Photobooth extends Sequelize.Model {
     // 다른 모델과의 관계 정의
     static associate(db) {
 
+        // 다대다 관계
+        this.belongsToMany(db.User, {
+            through: 'Photobooth_like',
+            foreignKey: 'photobooth_id',
+            otherKey: 'user_id',
+            as: 'likedByUsers',
+            timestamps: false,
+        })
     }
 };
 

--- a/models/user.js
+++ b/models/user.js
@@ -18,6 +18,11 @@ class User extends Sequelize.Model {
                     unique: true,
                     comment: '이메일',
                 },
+                profileImage: {
+                    type: Sequelize.STRING(255),
+                    allowNull: true,
+                    comment: '프로필 사진',
+                },
             },
             {
                 modelName: 'User',  // 모델 이름
@@ -34,7 +39,15 @@ class User extends Sequelize.Model {
 
     // 다른 모델과의 관계 정의
     static associate(db) {
-
+        
+        // 다대다 관계
+        this.belongsToMany(db.Photobooth, {
+            through: 'Photobooth_like',
+            foreignKey: 'user_id',
+            otherKey: 'photobooth_id',
+            as: 'likedBooths',
+            timestamps: false,
+        });
     }
 };
 

--- a/passport/kakaoStrategy.js
+++ b/passport/kakaoStrategy.js
@@ -33,6 +33,7 @@ module.exports = () => {
                 const newUser = await User.create({
                     name: profile.displayName,
                     email: profile._json && profile._json.kakao_account.email,
+                    profileImage: profile._json.properties.profile_image,
                 });
 
                 const token = jwt.sign(

--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -1,0 +1,14 @@
+const express = require('express');
+const router = express.Router();
+const { getUserById, updateUser, deleteUser } = require('../controllers/userController');
+
+// (마이페이지) 회원 조회 라우터
+router.get('/:user_id', getUserById);
+
+// 회원정보 수정 라우터
+router.post('/update/:user_id', updateUser);
+
+// 회원 탈퇴 라우터
+router.get('/delete/:user_id', deleteUser);
+
+module.exports = router;


### PR DESCRIPTION
## 🚀 About

> feat #5

  - feat : Photobooth_like 중간테이블 생성 및 컨트롤러 추가
  - feat : User 관련 api 제작
  - feat : User 에 프로필 사진을 위한 컬럼 추가
  - refactor : models/index.js 에서 관계 설정은 테이블 정의 뒤로 가야해서 순서만 수정
    
## ✅ Key Changes

- 포토부스 즐겨찾기를 위한 Photobooth_like 중간테이블 생성
- 포토부스 즐겨찾기 생성, 삭제, 유저가 즐겨찾기한 포토부스 리스트 불러오기 컨트롤러 제작
- 회원 정보 조회, 수정, 회원 탈퇴 api 제작
- 프로필 사진(링크) 을 위한 컬럼 (profileImage) 추가

## 📍 Note

> Photobooth_like 는 Photobooth 테이블에 데이터 넣은 이후에 테스트해서 수정될 수 있습니다

> Photobooth_like 관련 컨트롤러는 아직 라우터 구현은 안한 상태입니다. (수정 가능성o)

> **User API 경로**
> 회원정보 조회 :`/api/user/:user_id`
> 회원정보 수정 : `/api/user/update/:user_id`
> 회원정보 탈퇴 : `/api/user/delete/:user_id`

