### PR TITLE
feat: 메인페이지 지도 구현 api 생성 및 swagger 문서화

### DIFF
--- a/build/swagger.yaml
+++ b/build/swagger.yaml
@@ -1,0 +1,371 @@
+openapi: 3.0.0
+info:
+  title: pocket4cut web1 API docs
+  description: pocket4cut web1팀의 API 문서입니다
+  version: 0.1.9
+servers:
+  - url: 'http://localhost:3000/'
+    description: pocket4cut
+paths:
+  '/api/user/{user_id}':
+    get:
+      summary: Get user by ID
+      description: 유저 ID를 통해 유저 정보를 조회합니다.
+      parameters:
+        - in: path
+          name: user_id
+          required: true
+          schema:
+            type: integer
+          description: 조회할 유저의 ID
+      responses:
+        '200':
+          description: 유저 정보 조회 성공
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  name:
+                    type: string
+                  email:
+                    type: string
+                  profileImage:
+                    type: string
+        '404':
+          description: 유저를 찾을 수 없음
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: 유저를 찾을 수 없습니다.
+        '500':
+          description: 서버 오류로 인한 유저 조회 실패
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: 유저 조회 실패
+    post:
+      summary: Update user information
+      description: 유저 정보를 수정합니다.
+      parameters:
+        - in: path
+          name: user_id
+          required: true
+          schema:
+            type: integer
+          description: 수정할 유저의 ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                email:
+                  type: string
+                profileImage:
+                  type: string
+      responses:
+        '200':
+          description: 유저 정보 업데이트 성공
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  name:
+                    type: string
+                  email:
+                    type: string
+                  profileImage:
+                    type: string
+        '404':
+          description: 유저를 찾을 수 없음
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: 유저를 찾을 수 없습니다.
+        '500':
+          description: 서버 오류로 인한 유저 수정 실패
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: 유저 업데이트 실패
+    delete:
+      summary: Delete user
+      description: 회원 탈퇴
+      parameters:
+        - in: path
+          name: user_id
+          required: true
+          schema:
+            type: integer
+          description: 삭제할 유저의 ID
+      responses:
+        '204':
+          description: 유저 탈퇴 성공
+        '404':
+          description: 유저를 찾을 수 없습니다.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: 유저를 찾을 수 없습니다.
+        '500':
+          description: 서버 오류로 인한 유저 삭제 실패
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: 유저 삭제 실패
+  '/api/review/{user_id}':
+    post:
+      summary: Create a new review
+      description: 포토부스에 대한 리뷰를 작성합니다.
+      parameters:
+        - in: path
+          name: user_id
+          required: true
+          schema:
+            type: integer
+          description: 작성자의 ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                booth_keyword:
+                  type: array
+                  items:
+                    type: string
+                  example:
+                    - 넓은 부스 공간
+                    - 청결한 부스
+                photo_keyword:
+                  type: array
+                  items:
+                    type: string
+                  example:
+                    - 빛번짐 없음
+                    - 선명한 화질
+                image_url:
+                  type: array
+                  items:
+                    type: string
+                  example:
+                    - 'https://example.com/image1.jpg'
+                    - 'https://example.com/image2.jpg'
+      responses:
+        '201':
+          description: 리뷰 작성 성공
+  /api/map:
+    get:
+      summary: Get photobooths near the current location
+      description: 유저의 현 위치를 기반으로 반경 1km 내의 포토부스 정보를 조회합니다. (유저가 위치 제공 안한다면 학교를 기본값으로 함)
+      parameters:
+        - in: query
+          name: latitude
+          schema:
+            type: string
+            example: '37.6329741'
+          description: 유저가 현재 위치하고 있는 장소의 위도
+        - in: query
+          name: longitude
+          schema:
+            type: string
+            example: '127.0798802'
+          description: 유저가 현재 위치하고 있는 장소의 경도
+        - in: query
+          name: brand
+          schema:
+            type: string
+            example: 포토이즘박스
+          description: 필터링할 브랜드명 (옵션)
+      responses:
+        '200':
+          description: 포토부스 정보 조회 성공
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - description: 브랜드 필터링이 없을 때의 응답
+                    type: object
+                    properties:
+                      photobooths:
+                        type: array
+                        description: 1km 반경 내의 포토부스들
+                        items:
+                          type: object
+                          properties:
+                            id:
+                              type: integer
+                              example: 280
+                            name:
+                              type: string
+                              example: 포토이즘 박스 공릉점
+                            latitude:
+                              type: number
+                              format: float
+                              example: 37.6267
+                            longitude:
+                              type: number
+                              format: float
+                              example: 127.077
+                            brand:
+                              type: string
+                              example: 포토이즘박스
+                            rating:
+                              type: number
+                              format: float
+                              example: 0
+                  - description: 브랜드 필터링이 있을 때의 응답
+                    type: object
+                    properties:
+                      brandPhotobooths:
+                        type: array
+                        description: 필터링한 브랜드에 해당하는 포토부스들
+                        items:
+                          type: object
+                          properties:
+                            id:
+                              type: integer
+                              example: 280
+                            name:
+                              type: string
+                              example: 포토이즘 박스 공릉점
+                            latitude:
+                              type: number
+                              format: float
+                              example: 37.6267
+                            longitude:
+                              type: number
+                              format: float
+                              example: 127.077
+                            brand:
+                              type: string
+                              example: 포토이즘박스
+                            rating:
+                              type: number
+                              format: float
+                              example: 0
+                      otherPhotobooths:
+                        type: array
+                        description: 필터링한 브랜드에 해당하지 않는 포토부스들
+                        items:
+                          type: object
+                          properties:
+                            id:
+                              type: integer
+                              example: 1162
+                            name:
+                              type: string
+                              example: 포토시그니처 경춘숲
+                            latitude:
+                              type: number
+                              format: float
+                              example: 37.6266
+                            longitude:
+                              type: number
+                              format: float
+                              example: 127.077
+                            brand:
+                              type: string
+                              example: 포토시그니처
+                            rating:
+                              type: number
+                              format: float
+                              example: 0
+        '500':
+          description: Internal server error.
+  /api/map/search:
+    get:
+      summary: Search photobooths based on a location keyword
+      description: 검색어 키워드의 위치를 기반으로 반경 1km 내의 포토부스 정보를 조회합니다.
+      parameters:
+        - in: query
+          name: searchTerm
+          schema:
+            type: string
+            example: 명동역
+          description: '검색할 장소의 키워드 (구, 역, 건물명)'
+      responses:
+        '200':
+          description: 검색어 키워드 인근의 포토부스 조회 성공
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  place_name:
+                    type: string
+                    description: 검색어를 기반으로 표시된 지도의 중심 (검색어가 부정확한 경우 해당 키워드와 가장 가까운 장소로 선정)
+                    example: 명동역 4호선
+                  photobooths:
+                    type: array
+                    description: 키워드 장소 반경 1km 내의 포토부스들
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: integer
+                          example: 52
+                        name:
+                          type: string
+                          example: 포토이즘 박스 을지로 2호점
+                        latitude:
+                          type: number
+                          format: float
+                          example: 37.566
+                        longitude:
+                          type: number
+                          format: float
+                          example: 126.991
+                        brand:
+                          type: string
+                          example: 포토이즘박스
+                        rating:
+                          type: number
+                          format: float
+                          example: 0
+        '400':
+          description: 검색 실패 (검색어가 존재하지 않음)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: 검색어를 입력하세요.
+        '500':
+          description: Internal server error.

--- a/controllers/mapController.js
+++ b/controllers/mapController.js
@@ -1,0 +1,92 @@
+const { Sequelize } = require('../models');
+const Photobooth = require('../models/photobooth');
+const { Op } = require('sequelize');
+const axios = require('axios');
+
+// 현 위치 기반 인근 포토부스 조회
+const getBooth = async (req, res) => {
+    // 위경도 없으면 우리 학교 기준!
+    const { latitude = '37.6329741', longitude = '127.0798802', brand } = req.query;
+
+    // 반경 1km 설정
+    const radius = 1000;
+
+    try {
+        // 포토부스 조회
+        const photobooths = await Photobooth.findAll({
+            where: Sequelize.where(
+                Sequelize.fn(
+                    'ST_Distance_Sphere',
+                    Sequelize.literal(`POINT(${longitude}, ${latitude})`),
+                    Sequelize.literal(`POINT(longitude, latitude)`)
+                ),
+                {
+                    [Op.lte]: radius
+                }
+            )
+        });
+
+        if (brand) {
+            // 필터링을 원하는 브랜드가 존재하는 경우: 해당 브랜드의 포토부스와 해당 브랜드가 아닌 포토부스 별도로 제공
+            const brandPhotobooths = photobooths.filter(booth => booth.brand === brand );
+            const otherPhotobooths = photobooths.filter(booth => booth.brand !== brand );
+            res.json({brandPhotobooths, otherPhotobooths});
+        } else {
+            // 필터링 제한 없는 경우: 반경 내의 전체 포토부스 제공
+            res.json({ photobooths });
+        }
+    } catch (error) {
+        console.error(error);
+        res.status(500).json({ message: '서버 오류가 발생했습니다.' });
+    }
+};
+
+// 검색 기반 포토부스 조회
+const searchBooth = async (req, res) => {
+    const { searchTerm } = req.query;
+
+    if (!searchTerm) {
+        return res.status(400).json({ message: '검색어를 입력하세요.' });
+    }
+
+    // 반경 1km 설정
+    const radius = 1000;
+
+    try {
+        // 카카오지도 api에 해당 키워드 검색
+        const kakaoUrl = `https://dapi.kakao.com/v2/local/search/keyword.json?query=${searchTerm}`;
+        const kakaoSecretKey = process.env.KAKAO_ID;
+
+        const response = await axios.get(kakaoUrl, {
+            headers: {
+                Authorization: `KakaoAK ${kakaoSecretKey}`
+            }
+        });
+
+        // 키워드와 가장 근접한 장소를 중심으로 선택
+        console.log(response.data.documents[0].place_name);
+        const {x: longitude, y: latitude, place_name } = response.data.documents[0];
+
+        // 중심으로 채택된 장소의 위경도를 기준으로 반경 1km의 포토부스 검색
+        const photobooths = await Photobooth.findAll({
+            where: Sequelize.where(
+                Sequelize.fn(
+                    'ST_Distance_Sphere',
+                    Sequelize.literal(`POINT(${longitude}, ${latitude})`),
+                    Sequelize.literal(`POINT(longitude, latitude)`)
+                ),
+                {
+                    [Op.lte]: radius
+                }
+            )
+        });
+
+        // 중심 장소의 이름과 검색된 포토부스 정보 반환
+        res.json({ place_name, photobooths });
+    } catch(error) {
+        console.error(error);
+        res.status(500).json({ message: '서버 오류가 발생했습니다.' });
+    }
+}
+
+module.exports = { getBooth, searchBooth };

--- a/docs/map-search.yaml
+++ b/docs/map-search.yaml
@@ -1,0 +1,61 @@
+get:
+  summary: Search photobooths based on a location keyword
+  description: 검색어 키워드의 위치를 기반으로 반경 1km 내의 포토부스 정보를 조회합니다.
+  parameters:
+    - in: query
+      name: searchTerm
+      schema:
+        type: string
+        example: '명동역'
+      description: 검색할 장소의 키워드 (구, 역, 건물명)
+  responses:
+    '200':
+      description: 검색어 키워드 인근의 포토부스 조회 성공
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              place_name:
+                type: string
+                description: 검색어를 기반으로 표시된 지도의 중심 (검색어가 부정확한 경우 해당 키워드와 가장 가까운 장소로 선정)
+                example: '명동역 4호선'
+              photobooths:
+                type: array
+                description: 키워드 장소 반경 1km 내의 포토부스들
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                      example: 52
+                    name:
+                      type: string
+                      example: '포토이즘 박스 을지로 2호점'
+                    latitude:
+                      type: number
+                      format: float
+                      example: 37.566
+                    longitude:
+                      type: number
+                      format: float
+                      example: 126.991
+                    brand:
+                      type: string
+                      example: '포토이즘박스'
+                    rating:
+                      type: number
+                      format: float
+                      example: 0
+    '400':
+      description: 검색 실패 (검색어가 존재하지 않음)
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+                example: '검색어를 입력하세요.'
+    '500':
+      description: Internal server error.

--- a/docs/map.yaml
+++ b/docs/map.yaml
@@ -1,0 +1,118 @@
+get:
+  summary: Get photobooths near the current location
+  description: 유저의 현 위치를 기반으로 반경 1km 내의 포토부스 정보를 조회합니다. (유저가 위치 제공 안한다면 학교를 기본값으로 함)
+  parameters:
+    - in: query
+      name: latitude
+      schema:
+        type: string
+        example: '37.6329741'
+      description: 유저가 현재 위치하고 있는 장소의 위도
+    - in: query
+      name: longitude
+      schema:
+        type: string
+        example: '127.0798802'
+      description: 유저가 현재 위치하고 있는 장소의 경도
+    - in: query
+      name: brand
+      schema:
+        type: string
+        example: '포토이즘박스'
+      description: 필터링할 브랜드명 (옵션)
+  responses:
+    '200':
+      description: 포토부스 정보 조회 성공
+      content:
+        application/json:
+          schema:
+            oneOf:
+              - description: 브랜드 필터링이 없을 때의 응답
+                type: object
+                properties:
+                  photobooths:
+                    type: array
+                    description: 1km 반경 내의 포토부스들
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: integer
+                          example: 280
+                        name:
+                          type: string
+                          example: '포토이즘 박스 공릉점'
+                        latitude:
+                          type: number
+                          format: float
+                          example: 37.6267
+                        longitude:
+                          type: number
+                          format: float
+                          example: 127.077
+                        brand:
+                          type: string
+                          example: '포토이즘박스'
+                        rating:
+                          type: number
+                          format: float
+                          example: 0
+              - description: 브랜드 필터링이 있을 때의 응답
+                type: object
+                properties:
+                  brandPhotobooths:
+                    type: array
+                    description: 필터링한 브랜드에 해당하는 포토부스들
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: integer
+                          example: 280
+                        name:
+                          type: string
+                          example: '포토이즘 박스 공릉점'
+                        latitude:
+                          type: number
+                          format: float
+                          example: 37.6267
+                        longitude:
+                          type: number
+                          format: float
+                          example: 127.077
+                        brand:
+                          type: string
+                          example: '포토이즘박스'
+                        rating:
+                          type: number
+                          format: float
+                          example: 0
+                  otherPhotobooths:
+                    type: array
+                    description: 필터링한 브랜드에 해당하지 않는 포토부스들
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: integer
+                          example: 1162
+                        name:
+                          type: string
+                          example: '포토시그니처 경춘숲'
+                        latitude:
+                          type: number
+                          format: float
+                          example: 37.6266
+                        longitude:
+                          type: number
+                          format: float
+                          example: 127.077
+                        brand:
+                          type: string
+                          example: '포토시그니처'
+                        rating:
+                          type: number
+                          format: float
+                          example: 0
+    '500':
+      description: Internal server error.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -11,3 +11,7 @@ paths:
     $ref: './user.yaml'
   /api/review/{user_id}:
     $ref: './review.yaml'
+  /api/map:
+    $ref: './map.yaml'
+  /api/map/search:
+    $ref: './map-search.yaml'

--- a/index.js
+++ b/index.js
@@ -53,6 +53,8 @@ app.use('/api/review', reviewRouter);
 const userRouter = require('./routes/userRoutes');
 app.use('/api/user', userRouter);
 
+const mapRouter = require('./routes/mapRouters');
+app.use('/api/map', mapRouter);
 
 // 스웨거 세팅
 const swaggerUi = require('swagger-ui-express');

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "aws-sdk": "^2.1691.0",
+        "axios": "^1.7.7",
         "cookie-parser": "^1.4.6",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
@@ -223,6 +224,12 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -272,6 +279,17 @@
       "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -517,6 +535,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -624,6 +654,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/denque": {
@@ -874,12 +913,46 @@
         "node": ">=8"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
       "dependencies": {
         "is-callable": "^1.1.3"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/forwarded": {
@@ -1921,6 +1994,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "license": "ISC",
   "dependencies": {
     "aws-sdk": "^2.1691.0",
+    "axios": "^1.7.7",
     "cookie-parser": "^1.4.6",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",

--- a/routes/mapRouters.js
+++ b/routes/mapRouters.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const router = express.Router();
+
+const { getBooth, searchBooth } = require('../controllers/mapController');
+
+// 메인 페이지 지도 위에 표시할 포토부스 조회
+router.get('/', getBooth);
+
+// 검색어 입력 후 표시할 포토부스 조회
+router.get('/search', searchBooth);
+
+module.exports = router;


### PR DESCRIPTION
## 🚀 About

> feat #12 

  - feat : 메인페이지 지도 구현 API 생성
  - docs : 지도 관련 API 문서화

## ✅ Key Changes

- `/api/map` : 사용자의 현 위치를 기반으로 반경 1km 이내의 포토부스 정보를 조회하는 API
  - 쿼리파라미터 brand 로 브랜드별 필터링
- `/api/map/search` : 검색어로 입력한 키워드를 기반으로 카카오 지도 api에 검색해 가장 근접한 장소를 기준으로 반경 1km 내의 포토부스 정보 제공
- 두 API 관련 yaml 파일 작성해서 문서화

## 📍 Note

> `/api/map`에서 사용자의 현 위치를 받아오지 못한 경우는 기본값인 우리 학교를 중심으로 제공

> 브랜드별 필터링의 경우, 일단 브랜드 하나씩만 고를 수 있게 함

> 브랜드별 필터링이 성공하면, 응답으로 필터링한 브랜드에 해당하는 포토부스와 해당하지 않는 포토부스 정보들을 모두 제공

> 검색어가 없는 경우는 404에러 + '검색어를 입력하세요' 띄움

